### PR TITLE
val_dataloader random validation set edge case

### DIFF
--- a/data_provider/DS.py
+++ b/data_provider/DS.py
@@ -295,9 +295,7 @@ class DS:
         ii = 0
         while ii < self.opt.val_size:
 
-            i = random.randint(
-                self.predict_days, len(self.data) - 31 * self.predict_days - 1
-            )
+            i = random.randint(self.predict_days, len(self.data) - self.lens - 1)
             # Hydro year is from September to May, for all experiments and all methods.
             if (
                 (not np.isnan(self.data[i: i + self.lens]).any())


### PR DESCRIPTION
### Problem

As `self.lens = self.predict_days + self.train_days + 1` AND `i + self.lens` is used as an index in `self.sensor_data_norm1` and `self.R_data`, setting upper edge of `i` to `len(self.data) - 2 * self.predict_days - 1` is insufficient for any `self.train_days > self.predict_days * 2`, since edge case `i` values will be out of bounds of `self.data`.

### Example

```python
self.predict_days = 288
self.train_days = 1440
self.lens = self.predict_days + self.train_days + 1  # 288 + 1440 = 1729
self.data = []  # array of length 294528
self.sensor_data_norm1 = []  # array of length 294528

i = random.randint(self.predict_days, len(self.data) - 2 * self.predict_days - 1)  # i between 288 and 293951
np.isnan(self.sensor_data_norm1[i: i + self.lens]).any())  # throws for any i >= 292799
```

### Solution

Should work if upper boundary for `i` is set between `self.predict_days` and `self.lens - 1`